### PR TITLE
ARTUS-44 Add section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,3 @@ MCR.LayoutService.LastModifiedCheckPeriod=0
 MCR.UseXSLTemplateCache=false
 MCR.SASS.DeveloperMode=true
 ```
-
-For SOLR
-in [$MIR-HOME]/data/solr/configsets/mycore_main/conf/managed-schema add the following field:
-
-```
-<field name="artus.sections" type="string" indexed="true" stored="true" multiValued="false"/>
-```

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ MCR.LayoutService.LastModifiedCheckPeriod=0
 MCR.UseXSLTemplateCache=false
 MCR.SASS.DeveloperMode=true
 ```
+
+For SOLR
+in [$MIR-HOME]/data/solr/configsets/mycore_main/conf/managed-schema add the following field:
+
+```
+<field name="artus.sections" type="string" indexed="true" stored="true" multiValued="false"/>
+```

--- a/src/main/resources/META-INF/resources/content/search/complex_intern.xed
+++ b/src/main/resources/META-INF/resources/content/search/complex_intern.xed
@@ -99,7 +99,7 @@
                     uri="xslStyle:items2options:classification:editorComplete:-1:children:mir_institutes" />
                   <!--  Sektion  -->
                   <mir:template name="selectInput"
-                                xpath="condition[@field='artus.sections']/@value"
+                                xpath="condition[@field='artus_sections'][2]/@value"
                                 id="artus_sections"
                                 uri="xslStyle:items2options:classification:editor:-1:children:artus_sections"
                                 i18n="component.mods.metaData.dictionary.artus_sections"
@@ -107,17 +107,17 @@
 
                   <!-- DNB Sachgruppe -->
                   <mir:template name="selectInput"
-                    xpath="condition[@field='category.top'][2]/@value" id="inputSDNB1"
+                    xpath="condition[@field='category.top'][3]/@value" id="inputSDNB1"
                     i18n="editor.search.mir.sdnb" tooltip="editor.search.mir.sdnb.tooltip"
                     uri="xslStyle:items2options:classification:editorComplete:-1:children:SDNB" />
                   <!-- Genre -->
                   <mir:template name="selectInput"
-                    xpath="condition[@field='category.top'][3]/@value" id="inputGenre1"
+                    xpath="condition[@field='category.top'][4]/@value" id="inputGenre1"
                     i18n="editor.search.mir.genre" tooltip="editor.search.genre.tooltip"
                     uri="xslStyle:items2options?allSelectable=true:classification:editorComplete:-1:children:mir_genres" />
                   <!-- Licenses -->
                   <mir:template name="selectInput"
-                    xpath="condition[@field='category.top'][4]/@value" id="inputLicense1"
+                    xpath="condition[@field='category.top'][5]/@value" id="inputLicense1"
                     i18n="editor.search.mir.license" tooltip="editor.search.license.tooltip"
                     uri="xslStyle:items2options:classification:editorComplete:-1:children:mir_licenses" />
                   <!-- Status -->

--- a/src/main/resources/META-INF/resources/content/search/complex_intern.xed
+++ b/src/main/resources/META-INF/resources/content/search/complex_intern.xed
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MyCoReWebPage>
+
+  <section xml:lang="de">
+    <head>
+      <meta name="title" content="Komplexe Suche" />
+      <meta name="description" content="Komplexe Suche über alle Publikationen" />
+    </head>
+  </section>
+  <section xml:lang="en">
+    <head>
+      <meta name="title" content="Complex search mask" />
+      <meta name="description" content="Complex search mask for all publications" />
+    </head>
+  </section>
+
+ <section xml:lang="all" xmlns:xed="http://www.mycore.de/xeditor" xmlns:mir="http://www.mycore.de/mir"
+          i18n="component.mods.editor.search.complex.pagetitle">
+    <xed:form class="form-horizontal" role="form">
+      <xed:cleanup-rule xpath="//condition" relevant-if="(string-length(@value) &gt; 0) or value[string-length(text()) &gt; 0 ]" />
+      <xed:cleanup-rule xpath="//boolean" relevant-if="boolean|condition" />
+      <xed:cleanup-rule xpath="//condition[@selectable='true']" relevant-if="@id = ../selectCondition/@keep" />
+      <xed:cleanup-rule xpath="//*/@selectable|//selectCondition" relevant-if="false()" />
+      <xed:source uri="searchInput:{id}" />
+      <xed:source uri="webapp:editor/search/template/complex_intern.xml" />
+      <xed:bind xpath="query">
+        <xed:bind xpath="@mask" default="content/search/complex_intern.xed" />
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">
+              <xed:output i18n="component.mods.editor.search.label" />
+            </h3>
+          </div>
+          <div class="card-body row">
+
+            <xed:bind xpath="conditions/boolean/boolean">
+              <xed:repeat xpath="boolean[@operator='and']">
+                <div class="jumbotron col-md-10">
+                  <xed:repeat
+                    xpath="condition[contains(',mods.title,mods.author,mods.name,allMeta,', concat(',',@field,','))]"
+                    method="clone">
+                    <!-- Title -->
+                    <div class="form-group row">
+                      <div class="col-md-3">
+                        <xed:bind xpath="@field">
+                          <select class="form-control">
+                            <option value="mods.title">
+                              <xed:output i18n="editor.search.mir.title" />
+                            </option>
+                            <option value="mods.author">
+                              <xed:output i18n="editor.search.mir.author" />
+                            </option>
+                            <option value="mods.name">
+                              <xed:output i18n="editor.search.mir.name" />
+                            </option>
+                            <option value="allMeta">
+                              <xed:output i18n="editor.search.mir.metadata" />
+                            </option>
+                          </select>
+                        </xed:bind>
+                      </div>
+                      <div class="col-md-2">
+                        <xed:bind xpath="@operator">
+                          <select class="form-control">
+                            <option value="contains">
+                              <xed:output i18n="editor.search.contains" />
+                            </option>
+                            <option value="like">
+                              <xed:output i18n="editor.search.like" />
+                            </option>
+                            <option value="phrase">
+                              <xed:output i18n="editor.search.phrase" />
+                            </option>
+                          </select>
+                        </xed:bind>
+                      </div>
+                      <div class="col-md-7 row">
+                        <div class="col-md-8">
+                          <xed:bind xpath="@value">
+                            <input type="text" class="form-control" />
+                          </xed:bind>
+                        </div>
+                        <div class="btn-group col-md-4">
+                          <span class="float-right">
+                            <xed:controls>insert remove</xed:controls>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </xed:repeat>
+                  <!-- Identifier -->
+                  <mir:template name="textInput"
+                    xpath="condition[@field='id,isbn,mods.identifier']/@value" id="inputIdentifier1"
+                    i18n="editor.search.mir.identifier" tooltip="editor.search.mir.identifier.tooltip" />
+                  <!-- Institution -->
+                  <mir:template name="selectInput"
+                    xpath="condition[@field='category.top'][1]/@value" id="inputInst1"
+                    i18n="editor.search.mir.institute" tooltip="editor.search.mir.institute.tooltip"
+                    uri="xslStyle:items2options:classification:editorComplete:-1:children:mir_institutes" />
+                  <!--  Sektion  -->
+                  <mir:template name="selectInput"
+                                xpath="condition[@field='artus.sections']/@value"
+                                id="artus_sections"
+                                uri="xslStyle:items2options:classification:editor:-1:children:artus_sections"
+                                i18n="component.mods.metaData.dictionary.artus_sections"
+                                tooltip="artus.help.artus.sections" />
+
+                  <!-- DNB Sachgruppe -->
+                  <mir:template name="selectInput"
+                    xpath="condition[@field='category.top'][2]/@value" id="inputSDNB1"
+                    i18n="editor.search.mir.sdnb" tooltip="editor.search.mir.sdnb.tooltip"
+                    uri="xslStyle:items2options:classification:editorComplete:-1:children:SDNB" />
+                  <!-- Genre -->
+                  <mir:template name="selectInput"
+                    xpath="condition[@field='category.top'][3]/@value" id="inputGenre1"
+                    i18n="editor.search.mir.genre" tooltip="editor.search.genre.tooltip"
+                    uri="xslStyle:items2options?allSelectable=true:classification:editorComplete:-1:children:mir_genres" />
+                  <!-- Licenses -->
+                  <mir:template name="selectInput"
+                    xpath="condition[@field='category.top'][4]/@value" id="inputLicense1"
+                    i18n="editor.search.mir.license" tooltip="editor.search.license.tooltip"
+                    uri="xslStyle:items2options:classification:editorComplete:-1:children:mir_licenses" />
+                  <!-- Status -->
+                  <mir:template name="selectInput"
+                    xpath="condition[@field='state']/@value" id="inputStatus1"
+                    i18n="editor.search.status" tooltip="editor.search.status.tooltip"
+                    uri="xslStyle:items2options:classification:editor:-1:children:state" />
+                  <!-- Datum -->
+                  <div class="form-group row">
+                    <xed:bind xpath="condition[@field='mods.dateIssued']">
+                      <label for="inputDate1" class="col-md-3 col-form-label text-md-right">
+                        <xed:output i18n="component.mods.metaData.dictionary.dateIssued" />
+                      </label>
+                      <div class="col-md-2">
+                        <xed:bind xpath="@operator">
+                          <select class="form-control">
+                            <option value="=">=</option>
+                            <option value="&gt;">&gt;</option>
+                            <option value="&gt;=">&gt;=</option>
+                            <option value="&lt;">&lt;</option>
+                            <option value="&lt;=">&lt;=</option>
+                          </select>
+                        </xed:bind>
+                      </div>
+                      <div class="col-md-7">
+                        <xed:bind xpath="@value">
+                          <input type="text" class="form-control" id="inputDate1"
+                            placeholder="YYYY-MM-DD" />
+                        </xed:bind>
+                      </div>
+                    </xed:bind>
+                  </div>
+                  <!-- Volltext -->
+                  <div class="form-group row">
+                    <label for="inputFulltext1" class="col-md-3 col-form-label text-md-right">
+                      <xed:output i18n="mir.dropdown.content" />
+                    </label>
+                    <div class="col-md-9">
+                      <div class="input-group">
+                        <xed:bind xpath="condition[@field='derCount'][@value='0'][@operator='&gt;'][@selectable='true'][@id='condFullText']" />
+                        <xed:bind xpath="condition[@field='worldReadableComplete'][@value='true'][@operator='='][@selectable='true'][@id='condOpenAccess']" />
+                                    <!-- selectCondition must always be after @selectable conditions for xed:cleanup-rule to work -->
+                        <xed:bind xpath="selectCondition[@delete='true']/@keep">
+                          <select class="form-control input-md" id="inputFulltext1">
+                            <option value="">
+                              <xed:output i18n="mir.select" />
+                            </option>
+                            <option value="condFullText">
+                              <xed:output i18n="editor.search.mir.hasFiles" />
+                            </option>
+                            <option value="condOpenAccess">
+                              <xed:output i18n="editor.search.mir.openAccess" />
+                            </option>
+                          </select>
+                          <span class="input-group-append" data-toggle="tooltip" data-html="true"
+                                title="{i18n:editor.search.fulltext.tooltip}">
+                            <i class="fas fa-info-circle input-group-text"/>
+                          </span>
+                        </xed:bind>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-2">
+                  <div class="btn-group">
+                    <xed:controls>insert remove</xed:controls>
+                  </div>
+                </div>
+              </xed:repeat>
+              <div class="form-group row col-12">
+                <div class="offset-md-3 col-md-9 row">
+                  <label for="Connect1" class="col-md-6" style="padding-left:0">
+                    <xed:output i18n="editor.search.connect" />
+                  </label>
+                  <div class="col-md-3">
+                    <xed:bind xpath="@operator" default="and">
+                      <select id="Connect1" class="form-control">
+                        <option value="and">
+                          <xed:output i18n="editor.search.and" />
+                        </option>
+                        <option value="or">
+                          <xed:output i18n="editor.search.or" />
+                        </option>
+                      </select>
+                    </xed:bind>
+                  </div>
+
+                </div>
+              </div>
+            </xed:bind>
+
+            <!-- sort -->
+            <xed:bind xpath="sortBy/field">
+              <div class="form-group row col-12">
+                <div class="offset-md-3 col-md-9 row">
+                  <label for="Connect1" class="col-md-2" style="padding-left:0">
+                    <xed:output i18n="editor.search.sortby" />
+                  </label>
+                  <div class="col-md-4">
+                    <xed:bind xpath="@name">
+                      <select class="form-control">
+                        <option value="mods.dateIssued">
+                          <xed:output i18n="component.mods.metaData.dictionary.dateIssued" />
+                        </option>
+                        <option value="score">
+                          <xed:output i18n="editor.search.score" />
+                        </option>
+                      </select>
+                    </xed:bind>
+                  </div>
+                  <div class="col-md-3">
+                    <xed:bind xpath="@order">
+                      <select class="form-control">
+                        <option value="descending">
+                          <xed:output i18n="editor.search.descending" />
+                        </option>
+                        <option value="ascending">
+                          <xed:output i18n="editor.search.ascending" />
+                        </option>
+                      </select>
+                    </xed:bind>
+                  </div>
+                </div>
+              </div>
+            </xed:bind>
+          </div>
+
+          <!-- submit -->
+          <div class="card-footer clearfix">
+            <div class="float-right">
+              <mir:template name="submitButton" i18n="editor.search.search"
+                target="servlet_MCRQLSearchServlet" order="primary-button"/>
+            </div>
+          </div>
+        </div>
+
+      </xed:bind>
+    </xed:form>
+  </section>
+</MyCoReWebPage>

--- a/src/main/resources/META-INF/resources/editor/editor-customization.xed
+++ b/src/main/resources/META-INF/resources/editor/editor-customization.xed
@@ -103,30 +103,25 @@
 
 
     <!-- ========== project specific templates ========== -->
-    <xed:template id="artus.sections">
-        <xed:bind xpath="mods:classification[@authority='artus_sections']">
-            <div class="mir-form-group row required {$xed-validation-marker}">
+        <xed:template id="artus.sections">
+            <div class="form-group row">
                 <label class="col-md-3 col-form-label text-right">
-                    <xed:output i18n="component.mods.metaData.dictionary.artus_sections"/>
-                    :
+                    <xed:output i18n="component.mods.metaData.dictionary.artus_sections" />
                 </label>
-                <div class="col-md-6">
-                    <select class="form-control form-control-inline mir-form__js-select--large form-select">
-                        <option value="">
-                            <xed:output i18n="mir.select"/>
-                        </option>
-                        <xed:include uri="xslStyle:items2options:classification:editor:-1:children:artus_sections"/>
-                    </select>
-                </div>
-                <mir:help-pmud help-text="{i18n:artus.help.artus.sections}"/>
+                <xed:bind xpath="mods:classification[@authorityURI='https://arthurianbibliography.info/classifications/artus_sections']/@displayLabel" set="artus_sections" />
+                <xed:bind xpath="mods:classification[@authorityURI='https://arthurianbibliography.info/classifications/artus_sections']/@valueURIxEditor">
+                    <div class="col-md-6">
+                        <div class="controls">
+                            <select class="form-control form-control-inline">
+                                <option value=""><xed:output i18n="mir.select.optional" /></option>
+                                <xed:include uri="xslStyle:items2options:classification:editor:-1:children:artus_sections" />
+                            </select>
+                        </div>
+                    </div>
+                    <mir:help-pmud help-text="{i18n:artus.help.artus.sections}" pmud="false" />
+                </xed:bind>
             </div>
-        </xed:bind>
-        <xed:validate
-                xpath="//mods:mods/mods:classification[@authority='artus_sections']"
-                required="true" i18n="mir.validation.artus_sections"
-                display="global"/>
-    </xed:template>
-
+        </xed:template>
 
 </xed:template>
 

--- a/src/main/resources/META-INF/resources/editor/editor-customization.xed
+++ b/src/main/resources/META-INF/resources/editor/editor-customization.xed
@@ -120,6 +120,11 @@
                     </div>
                     <mir:help-pmud help-text="{i18n:artus.help.artus.sections}" pmud="false" />
                 </xed:bind>
+
+                <xed:validate
+                        xpath="//mods:classification[@authorityURI='https://arthurianbibliography.info/classifications/artus_sections']/@valueURIxEditor"
+                        required="true" i18n="mir.validation.artus_sections"
+                        display="global"/>
             </div>
         </xed:template>
 

--- a/src/main/resources/META-INF/resources/editor/editor-customization.xed
+++ b/src/main/resources/META-INF/resources/editor/editor-customization.xed
@@ -2,83 +2,89 @@
 
 <xed:template xmlns:xed="http://www.mycore.de/xeditor" xmlns:mir="http://www.mycore.de/mir">
 
-  <!-- ========== extend editor-genres.xed ========== -->
-  <xed:modify ref="admin.fields">
-    <!-- for details see
-         https://cmswiki.rrz.uni-hamburg.de/hummel/MyCoRe/Organisation/AnwenderWorkshop2018?action=AttachFile&do=view&target=MyCoRe+XEditor+Erweiterungen+2018-11-14.pdf
-         https://cmswiki.rrz.uni-hamburg.de/hummel/MyCoRe/Organisation/AnwenderWorkshop2018?action=AttachFile&do=view&target=MCR-Workshop2018_Rochowski_XEditor_Erweiterungen_Praxis.pdf
-    -->
-  </xed:modify>
+    <!-- ========== extend editor-genres.xed ========== -->
+    <xed:modify ref="admin.fields">
 
-  <xed:template id="genres.monograph">
-    <xed:include ref="title.original" />
-    <xed:include ref="author.repeated" />
-    <xed:include ref="genres.book.common" />
-  </xed:template>
+        <xed:include ref="artus.sections" after="genre"/>
 
-  <!-- ========== overwrite mir templates and set them empty ========== -->
+        <!-- for details see
+             https://cmswiki.rrz.uni-hamburg.de/hummel/MyCoRe/Organisation/AnwenderWorkshop2018?action=AttachFile&do=view&target=MyCoRe+XEditor+Erweiterungen+2018-11-14.pdf
+             https://cmswiki.rrz.uni-hamburg.de/hummel/MyCoRe/Organisation/AnwenderWorkshop2018?action=AttachFile&do=view&target=MCR-Workshop2018_Rochowski_XEditor_Erweiterungen_Praxis.pdf
+        -->
+    </xed:modify>
 
-  <xed:template id="sdnb">
-      <!-- do nothing -->
-  </xed:template>
 
-  <xed:template id="sdnb.repeat">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="genres.monograph">
+        <xed:include ref="title.original"/>
+        <xed:include ref="author.repeated"/>
+        <xed:include ref="genres.book.common"/>
+    </xed:template>
 
-  <xed:template id="institutes">
-      <!-- do nothing -->
-  </xed:template>
+    <!-- ========== overwrite mir templates and set them empty ========== -->
 
-  <xed:template id="institutes.repeat">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="sdnb">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="sdnb.repeat">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark.journal.relItemsearch">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="institutes">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark.book.relItemsearch">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="institutes.repeat">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark.collection.relItemsearch">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="shelfmark">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark.festschrift.relItemsearch">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="shelfmark.journal.relItemsearch">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark.lexicon.relItemsearch">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="shelfmark.book.relItemsearch">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark.proceedings.relItemsearch">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="shelfmark.collection.relItemsearch">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="shelfmark.proceedings.relItemsearch">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="shelfmark.festschrift.relItemsearch">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="embargo">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="shelfmark.lexicon.relItemsearch">
+        <!-- do nothing -->
+    </xed:template>
 
-  <xed:template id="embargo.datetimepicker">
-      <!-- do nothing -->
-  </xed:template>
+    <xed:template id="shelfmark.proceedings.relItemsearch">
+        <!-- do nothing -->
+    </xed:template>
 
-  <!-- ========== validation ========== -->
-  <xed:template id="validation-rules">
-    <xed:load-resource name="mir_genres" uri="classification:metadata:-1:children:mir_genres" />
-    <xed:validate xpath="//mods:mods/mods:genre[@authorityURI=$mir_genres/label[@xml:lang='x-uri']/@text]/@valueURIxEditor" required="true"
-      i18n="mir.validation.genre" display="global" />
+    <xed:template id="shelfmark.proceedings.relItemsearch">
+        <!-- do nothing -->
+    </xed:template>
+
+    <xed:template id="embargo">
+        <!-- do nothing -->
+    </xed:template>
+
+    <xed:template id="embargo.datetimepicker">
+        <!-- do nothing -->
+    </xed:template>
+
+    <!-- ========== validation ========== -->
+    <xed:template id="validation-rules">
+        <xed:load-resource name="mir_genres" uri="classification:metadata:-1:children:mir_genres"/>
+        <xed:validate
+                xpath="//mods:mods/mods:genre[@authorityURI=$mir_genres/label[@xml:lang='x-uri']/@text]/@valueURIxEditor"
+                required="true"
+                i18n="mir.validation.genre" display="global"/>
 
     <xed:validate xpath="//mods:mods/mods:identifier[@type='isbn']|//mods:relatedItem[contains(@xlink:href,'mods_00000000')]/mods:identifier[@type='isbn']" matches="^((978|979)-?)?([\d -]{12}|\d{9})(\d|X)$" i18n="mir.validation.isbn" display="global" />
     <xed:validate xpath="//mods:mods/mods:identifier[@type='issn']|//mods:relatedItem[contains(@xlink:href,'mods_00000000')]/mods:identifier[@type='issn']" matches="[\dX]{4}\-[\dX]{4}" i18n="mir.validation.issn" display="global" />
@@ -88,13 +94,38 @@
     <xed:validate xpath="//mods:mods/mods:identifier[@type='ppn']" class="org.mycore.mir.validation.MIRValidationHelper" method="validatePPN" display="global" i18n="mir.validation.ppn" />
     <xed:validate xpath="//mods:url|//mods:abstract/@xlink:href" matches="(ftp|http|https)://[\w\d.]+\S*" i18n="mir.validation.url" display="global" />
     <xed:validate xpath="//mods:*[@encoding='w3cdtf'][not(ancestor::mods:recordInfo)]|//mods:mods/mods:accessCondition[@type='embargo']" matches="\d{4}(\-\d{2}(\-\d{2})?)?" type="datetime" format="yyyy;yyyy-MM;yyyy-MM-dd" i18n="mir.validation.date"
-      display="global" />
-    <xed:validate xpath="//mods:*[@encoding='iso8601']" matches="\d{4}(\d{2}(\d{2})?)?(T\d{2}\d{2}\d{2})?(\/\d{4}(\d{2}(\d{2})?)?(T\d{2}\d{2}\d{2})?)?" display="global"  i18n="mir.validation.date.iso8601"/>
-    <xed:validate xpath="//mods:part/@order" type="integer" display="global" i18n="mir.validation.order" />
-  </xed:template>
+                      display="global"/>
+        <xed:validate xpath="//mods:*[@encoding='iso8601']"
+                      matches="\d{4}(\d{2}(\d{2})?)?(T\d{2}\d{2}\d{2})?(\/\d{4}(\d{2}(\d{2})?)?(T\d{2}\d{2}\d{2})?)?"
+                      display="global" i18n="mir.validation.date.iso8601"/>
+        <xed:validate xpath="//mods:part/@order" type="integer" display="global" i18n="mir.validation.order"/>
+    </xed:template>
 
 
-  <!-- ========== project specific templates ========== -->
+    <!-- ========== project specific templates ========== -->
+    <xed:template id="artus.sections">
+        <xed:bind xpath="mods:classification[@authority='artus_sections']">
+            <div class="mir-form-group row required {$xed-validation-marker}">
+                <label class="col-md-3 col-form-label text-right">
+                    <xed:output i18n="component.mods.metaData.dictionary.artus_sections"/>
+                    :
+                </label>
+                <div class="col-md-6">
+                    <select class="form-control form-control-inline mir-form__js-select--large form-select">
+                        <option value="">
+                            <xed:output i18n="mir.select"/>
+                        </option>
+                        <xed:include uri="xslStyle:items2options:classification:editor:-1:children:artus_sections"/>
+                    </select>
+                </div>
+                <mir:help-pmud help-text="{i18n:artus.help.artus.sections}"/>
+            </div>
+        </xed:bind>
+        <xed:validate
+                xpath="//mods:mods/mods:classification[@authority='artus_sections']"
+                required="true" i18n="mir.validation.artus_sections"
+                display="global"/>
+    </xed:template>
 
 
 </xed:template>

--- a/src/main/resources/classifications/artus_sections.xml
+++ b/src/main/resources/classifications/artus_sections.xml
@@ -3,6 +3,7 @@
              xsi:noNamespaceSchemaLocation="MCRClassification.xsd" ID="artus_sections">
     <label xml:lang="de" text="Sektionen" description="Liste der Sektionen"/>
     <label xml:lang="en" text="Sections" description="A list of sections"/>
+    <label xml:lang="x-uri" text="https://arthurianbibliography.info/classifications/artus_sections" />
     <categories>
         <category ID="AAG">
             <label xml:lang="de" text="Australia, Austria and Germany"/>

--- a/src/main/resources/classifications/artus_sections.xml
+++ b/src/main/resources/classifications/artus_sections.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mycoreclass xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:noNamespaceSchemaLocation="MCRClassification.xsd" ID="artus_sections">
+    <label xml:lang="de" text="Sektionen" description="Liste der Sektionen"/>
+    <label xml:lang="en" text="Sections" description="A list of sections"/>
+    <categories>
+        <category ID="AAG">
+            <label xml:lang="de" text="Australia, Austria and Germany"/>
+            <label xml:lang="en" text="Australia, Austria and Germany"/>
+        </category>
+        <category ID="FGBI">
+            <label xml:lang="de" text="France, Great Britain and Ireland"/>
+            <label xml:lang="en" text="France, Great Britain and Ireland"/>
+        </category>
+        <category ID="IJNF">
+            <label xml:lang="de" text="Italy, Japan, Netherlands and Flanders"/>
+            <label xml:lang="en" text="Italy, Japan, Netherlands and Flanders"/>
+        </category>
+        <category ID="NARSSPS">
+            <label xml:lang="de" text="North America, Romania, Scandinavia, Spain and Portugal, Switzerland"/>
+            <label xml:lang="en" text="North America, Romania, Scandinavia, Spain and Portugal, Switzerland"/>
+        </category>
+    </categories>
+</mycoreclass>

--- a/src/main/resources/config/reposis_artus/messages_de.properties
+++ b/src/main/resources/config/reposis_artus/messages_de.properties
@@ -1,0 +1,3 @@
+artus.help.artus.sections=Suche nach einem Dokument mit einer bestimmten Sektion
+mir.validation.artus_sections= Bitte w\u00E4hlen Sie eine Sektion aus
+component.mods.metaData.dictionary.artus_sections = Sektionen

--- a/src/main/resources/config/reposis_artus/messages_en.properties
+++ b/src/main/resources/config/reposis_artus/messages_en.properties
@@ -1,0 +1,4 @@
+artus.help.artus.sections=Search for a document with a specific section
+mir.validation.artus_sections= Please select a section
+component.mods.metaData.dictionary.artus_sections = Sections
+

--- a/src/main/resources/config/reposis_artus/mycore.properties
+++ b/src/main/resources/config/reposis_artus/mycore.properties
@@ -40,3 +40,5 @@ MIR.testEnvironment=false
 ##############################################################################
 # Customization of XEditor forms
 MIR.EditorForms.CustomIncludes=%MIR.EditorForms.CustomIncludes%,xslStyle:editor/mir2xeditor:webapp:editor/editor-customization.xed
+MCR.URIResolver.xslImports.badges=badges/mir-badges.xsl,badges/mir-badges-oa.xsl,badges/mir-badges-genre.xsl,badges/mir-badges-license.xsl,badges/mir-badges-date.xsl,badges/mir-badges-state.xsl,badges/mir-badges-section.xsl
+MCR.URIResolver.xslImports.solr-document=%MCR.URIResolver.xslImports.solr-document%,solr-artus-sections.xsl

--- a/src/main/resources/config/reposis_artus/solr/main/solr-schema.json
+++ b/src/main/resources/config/reposis_artus/solr/main/solr-schema.json
@@ -1,1 +1,9 @@
-[]
+[
+  {
+    "add-field": {
+      "name": "artus.sections",
+      "type": "string",
+      "indexed": true
+    }
+  }
+]

--- a/src/main/resources/config/reposis_artus/solr/main/solr-schema.json
+++ b/src/main/resources/config/reposis_artus/solr/main/solr-schema.json
@@ -1,7 +1,7 @@
 [
   {
     "add-field": {
-      "name": "artus.sections",
+      "name": "artus_sections",
       "type": "string",
       "indexed": true
     }

--- a/src/main/resources/setup_artus.txt
+++ b/src/main/resources/setup_artus.txt
@@ -1,1 +1,3 @@
 update classification from uri resource:classifications/rfc5646.xml
+load classification from uri resource:classifications/artus_sections.xml
+

--- a/src/main/resources/setup_artus.txt
+++ b/src/main/resources/setup_artus.txt
@@ -1,3 +1,3 @@
 update classification from uri resource:classifications/rfc5646.xml
 load classification from uri resource:classifications/artus_sections.xml
-
+reload solr configuration main in core main

--- a/src/main/resources/xsl/badges/mir-badges-section.xsl
+++ b/src/main/resources/xsl/badges/mir-badges-section.xsl
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                exclude-result-prefixes="mods xlink">
+
+    <xsl:import href="xslImport:badges:badges/mir-badges-section.xsl"/>
+    <xsl:include href="resource:xsl/badges/mir-badges-style-template.xsl"/>
+
+    <xsl:variable name="tooltip-sections"
+                  select="substring-before(document('i18n:component.mods.metaData.dictionary.artus_sections')/i18n/text(), ':')"/>
+
+    <xsl:template match="doc" mode="resultList">
+        <xsl:apply-imports/>
+        <xsl:if test="str[@name='artus.sections']">
+        <xsl:for-each select="str[@name='artus.sections']/text()">
+            <xsl:variable name="label">
+                <xsl:variable name="displayname" select="document(concat('callJava:org.mycore.common.xml.MCRXMLFunctions:getDisplayName:artus_sections:', .))"/>
+                <xsl:choose>
+                <xsl:when
+                        test="string-length($displayname) > 30">
+                    <xsl:value-of select="."/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$displayname"/>
+                </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="categid" select="."/>
+            <xsl:call-template name="output-badge">
+                <xsl:with-param name="of-type" select="'hit_section'"/>
+                <xsl:with-param name="badge-type" select="'badge-secondary'"/>
+                <xsl:with-param name="link"
+                                select="concat($ServletsBaseURL, 'solr/find?condQuery=*&amp;fq=', 'artus.sections', ':','%22', $categid, '%22')"/>
+                <xsl:with-param name="label"
+                                select="$label"/>
+                <xsl:with-param name="tooltip" select="$tooltip-sections"/>
+            </xsl:call-template>
+        </xsl:for-each>
+        </xsl:if>
+    </xsl:template>
+
+
+    <xsl:template match="mycoreobject" mode="mycoreobject-badge">
+        <xsl:apply-imports/>
+        <xsl:for-each select="//mods:mods/mods:classification[@authority='artus_sections']">
+            <xsl:variable name="class" select="@authority"/>
+            <xsl:variable name="categid" select="."/>
+            <xsl:variable name="label"
+                          select="document(concat('classification:metadata:-1:children:', $class, ':', $categid))
+                //category/label[@xml:lang=$CurrentLang]/@text"/>
+            <xsl:call-template name="output-badge">
+                <xsl:with-param name="of-type" select="'hit_section'"/>
+                <xsl:with-param name="badge-type" select="'badge-secondary'"/>
+                <xsl:with-param name="label" select="$label"/>
+                <xsl:with-param name="link"
+                                select="concat($ServletsBaseURL, 'solr/find?condQuery=*&amp;fq=', 'artus.sections', ':','%22', $categid, '%22')"/>
+                <xsl:with-param name="tooltip" select="$tooltip-sections"/>
+            </xsl:call-template>
+
+        </xsl:for-each>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/xsl/badges/mir-badges-section.xsl
+++ b/src/main/resources/xsl/badges/mir-badges-section.xsl
@@ -13,8 +13,8 @@
 
     <xsl:template match="doc" mode="resultList">
         <xsl:apply-imports/>
-        <xsl:if test="str[@name='artus.sections']">
-        <xsl:for-each select="str[@name='artus.sections']/text()">
+        <xsl:if test="str[@name='artus_sections']">
+        <xsl:for-each select="str[@name='artus_sections']/text()">
             <xsl:variable name="label">
                 <xsl:variable name="displayname" select="document(concat('callJava:org.mycore.common.xml.MCRXMLFunctions:getDisplayName:artus_sections:', .))"/>
                 <xsl:choose>
@@ -32,7 +32,7 @@
                 <xsl:with-param name="of-type" select="'hit_section'"/>
                 <xsl:with-param name="badge-type" select="'badge-secondary'"/>
                 <xsl:with-param name="link"
-                                select="concat($ServletsBaseURL, 'solr/find?condQuery=*&amp;fq=', 'artus.sections', ':','%22', $categid, '%22')"/>
+                                select="concat($ServletsBaseURL, 'solr/find?condQuery=*&amp;fq=', 'artus_sections', ':','%22', $categid, '%22')"/>
                 <xsl:with-param name="label"
                                 select="$label"/>
                 <xsl:with-param name="tooltip" select="$tooltip-sections"/>
@@ -44,21 +44,27 @@
 
     <xsl:template match="mycoreobject" mode="mycoreobject-badge">
         <xsl:apply-imports/>
-        <xsl:for-each select="//mods:mods/mods:classification[@authority='artus_sections']">
-            <xsl:variable name="class" select="@authority"/>
-            <xsl:variable name="categid" select="."/>
+        <xsl:for-each select="//mods:mods/mods:classification[
+        @authorityURI='https://arthurianbibliography.info/classifications/artus_sections']">
+            <xsl:variable name="categid" select="substring-after(@valueURI, '#')"/>
+            <xsl:variable name="class">
+                <xsl:value-of select="substring-after(@valueURI, '#')" />
+            </xsl:variable>
             <xsl:variable name="label"
-                          select="document(concat('classification:metadata:-1:children:', $class, ':', $categid))
+                          select="document(concat('classification:metadata:-1:children:artus_sections', ':', $categid))
                 //category/label[@xml:lang=$CurrentLang]/@text"/>
+
+            <!-- Generate the badge -->
             <xsl:call-template name="output-badge">
                 <xsl:with-param name="of-type" select="'hit_section'"/>
                 <xsl:with-param name="badge-type" select="'badge-secondary'"/>
                 <xsl:with-param name="label" select="$label"/>
                 <xsl:with-param name="link"
-                                select="concat($ServletsBaseURL, 'solr/find?condQuery=*&amp;fq=', 'artus.sections', ':','%22', $categid, '%22')"/>
+                                select="concat($ServletsBaseURL,
+                               'solr/find?condQuery=*&amp;fq=artus_sections:%22',
+                               $categid, '%22')"/>
                 <xsl:with-param name="tooltip" select="$tooltip-sections"/>
             </xsl:call-template>
-
         </xsl:for-each>
     </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/xsl/solr-artus-sections.xsl
+++ b/src/main/resources/xsl/solr-artus-sections.xsl
@@ -16,9 +16,10 @@
 
 
     <xsl:template match="mods:mods" mode="artus">
-        <xsl:for-each select="//mods:classification[@authority='artus_sections']">
-            <field name="artus.sections">
-                <xsl:value-of select="." />
+        <xsl:for-each select="//mods:mods/mods:classification[
+        @authorityURI='https://arthurianbibliography.info/classifications/artus_sections']">
+            <field name="artus_sections">
+                <xsl:value-of select="substring-after(@valueURI, '#')" />
             </field>
         </xsl:for-each>
 

--- a/src/main/resources/xsl/solr-artus-sections.xsl
+++ b/src/main/resources/xsl/solr-artus-sections.xsl
@@ -1,0 +1,27 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:mcrxml="xalan://org.mycore.common.xml.MCRXMLFunctions"
+                xmlns:xalan="http://xml.apache.org/xalan"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                exclude-result-prefixes="mods xlink"
+>
+    <xsl:import href="xslImport:solr-document:mir-solr.xsl" />
+    <xsl:include href="mods-utils.xsl" />
+
+    <xsl:template match="mycoreobject[contains(@ID,'_mods_')]">
+        <xsl:apply-imports />
+        <xsl:apply-templates select="metadata/def.modsContainer/modsContainer/mods:mods" mode="artus"/>
+        <field name="hasFiles">
+            <xsl:value-of select="count(structure/derobjects/derobject)&gt;0" />
+        </field>
+    </xsl:template>
+
+
+    <xsl:template match="mods:mods" mode="artus">
+        <xsl:for-each select="//mods:classification[@authority='artus_sections']">
+            <field name="artus.sections">
+                <xsl:value-of select="." />
+            </field>
+        </xsl:for-each>
+
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
[Link to Jira](https://jira.gbv.de/browse/ARTUS-44)


1. Sections have their own classification and are indexed and searchable in Solr
2. (solr Field and classification must be manually imported/set, according to README and setup_artus.txt)
3. There is a badge for each section. By clicking on the badge you can search for objects that have the same section (if they are published, regardless of if you are logged in or not. Not sure how to make it available for any status).
4. The names of the sections are very long. If the name has more than 30 characters and we are in the resultlist, the name is shortened down. 
5. Sections are searchable through complex intern search with a drop down
6. You can add a Section in the admin XEditor to a document. (not multivalued atm)
7. To have the badges show up and the solr index the new field I had to set two mycore properties to two new xsl files. 